### PR TITLE
Read emptyfile

### DIFF
--- a/srcs/event/HTTPServerEvent.cpp
+++ b/srcs/event/HTTPServerEvent.cpp
@@ -59,12 +59,6 @@ void	HTTPServerEvent::DeleteEvent(EventQueue* equeue)
 		case SEVENT_SOCKET_SEND:
 			equeue->SetIoEvent(ssocket_->GetFd(), ET_WRITE, EA_DELETE, this);
 			break;
-		case SEVENT_FILE_READ:
-		case SEVENT_FILE_WRITE:
-		case SEVENT_FILE_DELETE:
-		case SEVENT_ERRORPAGE_READ:
-			hserver_->DeleteMethodTargetFile();
-			break;
 		default: {}
 	}
 }

--- a/srcs/io/RegularFile.cpp
+++ b/srcs/io/RegularFile.cpp
@@ -1,6 +1,7 @@
 #include <unistd.h>
 #include <sstream>
 #include "RegularFile.hpp"
+#include "Stat.hpp"
 
 RegularFile::RegularFile(const std::string& path, const int open_mode)
 	: AIo(open(path.c_str(), open_mode)), path_(path), failed_(false)
@@ -15,6 +16,14 @@ RegularFile::RegularFile(const std::string& path, const int open_mode)
 		name_ = path_;
 	else
 		name_ = path_.substr(slash_pos + 1);
+
+	Stat	st(path_);
+	if (st.Fail())
+	{
+		failed_ = true;
+		return;
+	}
+	size_ = st.GetSize();
 }
 
 RegularFile::~RegularFile()
@@ -27,6 +36,7 @@ bool	RegularFile::Fail() const
 }
 
 const std::string&	RegularFile::GetName() const { return (name_); }
+size_t				RegularFile::GetSize() const { return (size_); }
 
 ssize_t		RegularFile::ReadFile(std::string* str) const
 {

--- a/srcs/io/RegularFile.hpp
+++ b/srcs/io/RegularFile.hpp
@@ -14,6 +14,7 @@ class RegularFile : public AIo
 
 		bool				Fail() const;
 		const std::string&	GetName() const;
+		size_t				GetSize() const;
 
 		ssize_t	ReadFile(std::string* str) const;
 		ssize_t	WriteToFile(const std::string& str) const;
@@ -22,6 +23,7 @@ class RegularFile : public AIo
 	private:
 		std::string		path_;
 		std::string		name_;
+		size_t			size_;
 		bool			failed_;
 };
 

--- a/srcs/server/HTTPMethod.hpp
+++ b/srcs/server/HTTPMethod.hpp
@@ -34,8 +34,10 @@ class HTTPMethod
 		void				MethodDisplay() const;
 
 	private:
-		LocationDirective	SelectLocation(const std::vector<LocationDirective>& locations) const;
-		e_StatusCode		Redirect(const std::string& location, const e_StatusCode status_code);
+		LocationDirective		SelectLocation(const std::vector<LocationDirective>& locations) const;
+		e_StatusCode			Redirect(const std::string& location, const e_StatusCode status_code);
+		e_HTTPServerEventType	PublishReadEvent(const e_HTTPServerEventType event_type);
+
 
 		// GET
 		bool	IsReadableFile(const std::string& access_path);

--- a/srcs/server/HTTPServer.cpp
+++ b/srcs/server/HTTPServer.cpp
@@ -25,7 +25,6 @@ HTTPServer::~HTTPServer()
 }
 
 int		HTTPServer::GetMethodTargetFileFd() const { return (method_->GetTargetFileFd()); }
-void	HTTPServer::DeleteMethodTargetFile() 	  { return (method_->DeleteTargetFile()); }
 
 e_HTTPServerEventType	HTTPServer::Run()
 {

--- a/srcs/server/HTTPServer.hpp
+++ b/srcs/server/HTTPServer.hpp
@@ -17,7 +17,6 @@ class HTTPServer
 		~HTTPServer();
 
 		int		GetMethodTargetFileFd() const;
-		void	DeleteMethodTargetFile();
 
 		e_HTTPServerEventType	Run();
 		e_HTTPServerEventType	RunExecHTTPMethod(const e_HTTPServerEventType event_type);

--- a/srcs/utils/Stat.cpp
+++ b/srcs/utils/Stat.cpp
@@ -45,7 +45,7 @@ const std::string	Stat::GetModifyTime() const
 	return (mtime.substr(0, mtime.size() - 1));
 }
 
-const std::string	Stat::GetSize() const
+const std::string	Stat::GetSizeStr() const
 {
 	if (failed_)
 		throw std::runtime_error("stat error");
@@ -56,4 +56,12 @@ const std::string	Stat::GetSize() const
 	else
 		ss << "-";
 	return (ss.str());
+}
+
+size_t	Stat::GetSize() const
+{
+	if (failed_)
+		throw std::runtime_error("stat error");
+
+	return (st_.st_size);
 }

--- a/srcs/utils/Stat.hpp
+++ b/srcs/utils/Stat.hpp
@@ -16,7 +16,8 @@ class Stat
 		bool				IsRegularFile() const;
 		bool				IsDirectory() const;
 		const std::string	GetModifyTime() const;
-		const std::string	GetSize() const;
+		const std::string	GetSizeStr() const;
+		size_t				GetSize() const;
 
 	private:
 		struct stat		st_;

--- a/tests/unit_tests/HTTPMethod_test/testsrcs/GET_test.cpp
+++ b/tests/unit_tests/HTTPMethod_test/testsrcs/GET_test.cpp
@@ -166,3 +166,10 @@ TEST_F(GETTest, DirForbiddenTest)
 	RunCommunication("GET /sub2/ HTTP/1.1\r\nHost: localhost:8080\r\n\r\n");
 	EXPECT_EQ(method_->GetStatusCode(), SC_FORBIDDEN);
 }
+
+TEST_F(GETTest, EmptyFileTest)
+{
+	RunCommunication("GET /empty.html HTTP/1.1\r\nHost: localhost:8080\r\n\r\n");
+	EXPECT_EQ(method_->GetStatusCode(), SC_OK);
+	EXPECT_EQ(method_->GetBody(), "");
+}


### PR DESCRIPTION
変更点
- 空のファイルのread の場合、読むデータがなくて、イベントが発生しないので、イベントに登録せず、status_code = 200 にして、終了するようにしました。
- メソッドで使ったファイルを、HTTPServerEvent.cpp のDeleteEvent で削除してましたが、奥まで潜るの大変なので、読み書き削除が終わった後に、削除してイベントからも消すことにしました！