### PR TITLE
fix ParseVersion()

### DIFF
--- a/srcs/server/HTTPRequest.cpp
+++ b/srcs/server/HTTPRequest.cpp
@@ -117,10 +117,7 @@ void	HTTPRequest::ParseVersion(const std::string& version)
 	const char*	tmp;
 	size_t		i;
 
-	if (version.at(0) != 'H')
-		throw HTTPError(SC_NOT_FOUND, "ParseVersion");
-
-	if (version.compare(1, 4, "TTP/"))
+	if (version.compare(0, 5, "HTTP/"))
 		throw HTTPError(SC_BAD_REQUEST, "ParseVersion");
 
 	tmp = version.c_str();

--- a/srcs/server/HTTPResponse.cpp
+++ b/srcs/server/HTTPResponse.cpp
@@ -30,7 +30,9 @@ e_HTTPServerEventType	HTTPResponse::SendResponse(const ServerSocket& ssocket)
 
 void HTTPResponse::CheckConnection()
 {
-	if (status_code_ == SC_BAD_REQUEST || status_code_ == SC_HTTP_VERSION_NOT_SUPPORTED)
+	if (status_code_ == SC_BAD_REQUEST || status_code_ == SC_REQUEST_TIMEOUT || status_code_ == SC_LENGTH_REQUIRED
+		|| status_code_ == SC_URI_TOO_LONG || status_code_ == SC_INTERNAL_SERVER_ERROR || status_code_ == SC_NOT_IMPLEMENTED
+		|| status_code_ == SC_SERVISE_UNAVAILABLE || status_code_ == SC_HTTP_VERSION_NOT_SUPPORTED)
 	{
 		connection_ = false;
 		return;

--- a/tests/unit_tests/HTTPRequest_test/HTTPRequest_test.cpp
+++ b/tests/unit_tests/HTTPRequest_test/HTTPRequest_test.cpp
@@ -166,7 +166,7 @@ TEST_F(RequestTest, test5)
 TEST_F(RequestTest, test6)
 {
 	RunCommunication("GET / tHTTP/1.1\r\n", 8080);
-	EXPECT_EQ(SC_NOT_FOUND, status_code_);
+	EXPECT_EQ(SC_BAD_REQUEST, status_code_);
 }
 
 TEST_F(RequestTest, test7)


### PR DESCRIPTION
・ParseVersion()の文字列チェックの１文字目だけ違ったエラーだった部分を削除
・connection closeになるstatus codeを追加